### PR TITLE
Adding request url and method to http logging

### DIFF
--- a/src/main/java/org/springframework/social/partnercenter/http/logging/Slf4jHttpRequestLogger.java
+++ b/src/main/java/org/springframework/social/partnercenter/http/logging/Slf4jHttpRequestLogger.java
@@ -19,7 +19,7 @@ public class Slf4jHttpRequestLogger implements HttpRequestLogger {
 	}
 
 	public String formatLog(Instant startTime, HttpRequest request, byte[] body){
-		return format("HTTP Request sent at %s: %s%s", startTime.toString(),
+		return format("HTTP %s Request sent to %s at %s: %s%s", request.getMethod(), request.getURI(), startTime.toString(),
 				httpHeaderLogFormatter.formatHeaderLogs(request.getHeaders()),
 				httpBodyLogFormatter.createRequestBodyLogString(body));
 	}


### PR DESCRIPTION
For some reason we only log the method and url in the response logging. That's weird.