### PR TITLE
Rest Client fails when making multiple requests without refreshing connection

### DIFF
--- a/src/main/java/org/springframework/social/partnercenter/api/PartnerCenterResponse.java
+++ b/src/main/java/org/springframework/social/partnercenter/api/PartnerCenterResponse.java
@@ -1,5 +1,7 @@
 package org.springframework.social.partnercenter.api;
 
+import static org.springframework.util.StringUtils.isEmpty;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -62,5 +64,9 @@ public class PartnerCenterResponse<T> {
 	public PartnerCenterResponse setContinuationToken(String continuationToken) {
 		this.continuationToken = continuationToken;
 		return this;
+	}
+
+	public boolean hasNext(){
+		return !isEmpty(links.getNext());
 	}
 }

--- a/src/main/java/org/springframework/social/partnercenter/http/client/RestClient.java
+++ b/src/main/java/org/springframework/social/partnercenter/http/client/RestClient.java
@@ -20,22 +20,22 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 public class RestClient implements RestResource {
 	private RestOperations restTemplate;
-	private UriComponentsBuilder builder;
+	private URI resourceBaseUri;
 
 	public RestClient(RestOperations restTemplate, URI resourceBaseUri) {
 		this.restTemplate = restTemplate;
-		this.builder = UriComponentsBuilder.fromUri(resourceBaseUri);
+		this.resourceBaseUri = resourceBaseUri;
 	}
 
 	public HttpRequestBuilder request(){
-		return new HttpRequestBuilder(this, this.builder);
+		return new HttpRequestBuilder(this, UriComponentsBuilder.fromUri(resourceBaseUri));
 	}
 	public HttpRequestBuilder request(String msRequestId, String msCorrelationId){
-		return new HttpRequestBuilder(this, this.builder, msRequestId, msCorrelationId);
+		return new HttpRequestBuilder(this, UriComponentsBuilder.fromUri(resourceBaseUri), msRequestId, msCorrelationId);
 	}
 
 	public HttpRequestBuilder request(MediaType mediaType){
-		return new HttpRequestBuilder(this, this.builder).header(HttpHeaders.CONTENT_TYPE, singletonList(mediaType.toString()));
+		return new HttpRequestBuilder(this, UriComponentsBuilder.fromUri(resourceBaseUri)).header(HttpHeaders.CONTENT_TYPE, singletonList(mediaType.toString()));
 	}
 
 	public ResponseEntity delete(URI uri, HttpHeaders headers){


### PR DESCRIPTION
Fixing issue in restClient. the UriComponentsBuilder was being created in the client instead of when creating a new request