### PR TITLE
Move Upgrade operation to AdminSubscriptionOperations

### DIFF
--- a/src/main/java/org/springframework/social/partnercenter/api/order/subscription/AdminSubscriptionOperations.java
+++ b/src/main/java/org/springframework/social/partnercenter/api/order/subscription/AdminSubscriptionOperations.java
@@ -2,8 +2,27 @@ package org.springframework.social.partnercenter.api.order.subscription;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.social.partnercenter.api.PartnerCenterResponse;
+import org.springframework.social.partnercenter.api.order.subscription.upgrade.Upgrade;
+import org.springframework.social.partnercenter.api.order.subscription.upgrade.UpgradeResult;
 
 public interface AdminSubscriptionOperations extends SubscriptionOperations{
 	ResponseEntity<PartnerCenterResponse<Conversion>> conversions(String customerTenantId, String subscriptionId);
 	ResponseEntity<ConversionResult> convertTrial(String customerTenantyId, String subscriptionId, Conversion conversion);
+
+	/**
+	 * Retrieves a list of offers available fot upgrade
+	 * @param customerId Customer tenant id.
+	 * @param subscriptionId Subscription to be upgraded
+	 * @return Upgrade[]
+	 */
+	ResponseEntity<PartnerCenterResponse<Upgrade>> getAvailableUpgrades(String customerId, String subscriptionId);
+
+	/**
+	 * Upgrades a customer's subscription to a specified target subscription.
+	 * @param customerId Customer tenant id.
+	 * @param sourceSubscriptionId Subscription to be upgraded.
+	 * @param upgrade Chosen offer to upgrade to.
+	 * @return UpgradeResult
+	 */
+	ResponseEntity<UpgradeResult> upgradeSubscription(String customerId, String sourceSubscriptionId, Upgrade upgrade);
 }

--- a/src/main/java/org/springframework/social/partnercenter/api/order/subscription/SubscriptionOperations.java
+++ b/src/main/java/org/springframework/social/partnercenter/api/order/subscription/SubscriptionOperations.java
@@ -7,7 +7,7 @@ import org.springframework.social.partnercenter.api.order.subscription.upgrade.U
 import org.springframework.social.partnercenter.api.order.subscription.upgrade.UpgradeResult;
 
 public interface SubscriptionOperations extends PagingResourceOperations<Subscription>{
-	ResponseEntity<Subscription> getById(String resellerCid, String id);
+	ResponseEntity<Subscription> getById(String customerTenantId, String id);
 	ResponseEntity<PartnerCenterResponse<Subscription>> getCustomersSubscriptions(String customerId);
 	ResponseEntity<PartnerCenterResponse<Subscription>> getSubscriptionsByOrderId(String customerId, String orderId);
 	ResponseEntity<PartnerCenterResponse<Subscription>> getAddOnsForBySubscriptionId(String customerId, String subscriptionId);
@@ -24,21 +24,4 @@ public interface SubscriptionOperations extends PagingResourceOperations<Subscri
 	 * @return Subscription
 	 */
 	ResponseEntity<Subscription> updateSubscriptionQuantity(String customerId, String subscriptionId, int qty);
-
-	/**
-	 * Retrieves a list of offers available fot upgrade
-	 * @param customerId Customer tenant id.
-	 * @param subscriptionId Subscription to be upgraded
-	 * @return Upgrade[]
-	 */
-	ResponseEntity<PartnerCenterResponse<Upgrade>> getAvailableUpgrades(String customerId, String subscriptionId);
-
-	/**
-	 * Upgrades a customer's subscription to a specified target subscription.
-	 * @param customerId Customer tenant id.
-	 * @param sourceSubscriptionId Subscription to be upgraded.
-	 * @param upgrade Chosen offer to upgrade to.
-	 * @return UpgradeResult
-	 */
-	ResponseEntity<UpgradeResult> upgradeSubscription(String customerId, String sourceSubscriptionId, Upgrade upgrade);
 }

--- a/src/main/java/org/springframework/social/partnercenter/api/order/subscription/impl/AdminSubscriptionTemplate.java
+++ b/src/main/java/org/springframework/social/partnercenter/api/order/subscription/impl/AdminSubscriptionTemplate.java
@@ -6,6 +6,8 @@ import org.springframework.social.partnercenter.api.PartnerCenterResponse;
 import org.springframework.social.partnercenter.api.order.subscription.AdminSubscriptionOperations;
 import org.springframework.social.partnercenter.api.order.subscription.Conversion;
 import org.springframework.social.partnercenter.api.order.subscription.ConversionResult;
+import org.springframework.social.partnercenter.api.order.subscription.upgrade.Upgrade;
+import org.springframework.social.partnercenter.api.order.subscription.upgrade.UpgradeResult;
 import org.springframework.social.partnercenter.http.client.RestResource;
 
 public class AdminSubscriptionTemplate extends SubscriptionTemplate implements AdminSubscriptionOperations {
@@ -29,5 +31,19 @@ public class AdminSubscriptionTemplate extends SubscriptionTemplate implements A
 		return restResource.request()
 				.pathSegment(customerTenantyId, SUBSCRIPTIONS, subscriptionId, CONVERSIONS)
 				.post(conversion, ConversionResult.class);
+	}
+
+	@Override
+	public ResponseEntity<PartnerCenterResponse<Upgrade>> getAvailableUpgrades(String customerId, String subscriptionId) {
+		return restResource.request()
+				.pathSegment(customerId, SUBSCRIPTIONS, subscriptionId, "upgrades")
+				.get(new ParameterizedTypeReference<PartnerCenterResponse<Upgrade>>() {});
+	}
+
+	@Override
+	public ResponseEntity<UpgradeResult> upgradeSubscription(String customerId, String sourceSubscriptionId, Upgrade upgrade) {
+		return restResource.request()
+				.pathSegment(customerId, SUBSCRIPTIONS, sourceSubscriptionId, "upgrades")
+				.post(upgrade, UpgradeResult.class);
 	}
 }

--- a/src/main/java/org/springframework/social/partnercenter/api/order/subscription/impl/SubscriptionTemplate.java
+++ b/src/main/java/org/springframework/social/partnercenter/api/order/subscription/impl/SubscriptionTemplate.java
@@ -1,8 +1,5 @@
 package org.springframework.social.partnercenter.api.order.subscription.impl;
 
-import static org.springframework.social.partnercenter.api.order.subscription.SubscriptionStatus.ACTIVE;
-import static org.springframework.social.partnercenter.api.order.subscription.SubscriptionStatus.SUSPENDED;
-
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.ResponseEntity;
 import org.springframework.social.partnercenter.PartnerCenter;
@@ -10,9 +7,10 @@ import org.springframework.social.partnercenter.api.PagingResourceTemplate;
 import org.springframework.social.partnercenter.api.PartnerCenterResponse;
 import org.springframework.social.partnercenter.api.order.subscription.Subscription;
 import org.springframework.social.partnercenter.api.order.subscription.SubscriptionOperations;
-import org.springframework.social.partnercenter.api.order.subscription.upgrade.Upgrade;
-import org.springframework.social.partnercenter.api.order.subscription.upgrade.UpgradeResult;
 import org.springframework.social.partnercenter.http.client.RestResource;
+
+import static org.springframework.social.partnercenter.api.order.subscription.SubscriptionStatus.ACTIVE;
+import static org.springframework.social.partnercenter.api.order.subscription.SubscriptionStatus.SUSPENDED;
 
 public class SubscriptionTemplate extends PagingResourceTemplate<Subscription> implements SubscriptionOperations {
 
@@ -95,19 +93,5 @@ public class SubscriptionTemplate extends PagingResourceTemplate<Subscription> i
 		ResponseEntity<Subscription> subscription = getById(customerId, subscriptionId);
 		subscription.getBody().setQuantity(qty);
 		return updateSubscription(customerId, subscriptionId, subscription.getBody());
-	}
-
-	@Override
-	public ResponseEntity<PartnerCenterResponse<Upgrade>> getAvailableUpgrades(String customerId, String subscriptionId) {
-		return restResource.request()
-				.pathSegment(customerId, SUBSCRIPTIONS, subscriptionId, "upgrades")
-				.get(new ParameterizedTypeReference<PartnerCenterResponse<Upgrade>>() {});
-	}
-
-	@Override
-	public ResponseEntity<UpgradeResult> upgradeSubscription(String customerId, String sourceSubscriptionId, Upgrade upgrade) {
-		return restResource.request()
-				.pathSegment(customerId, SUBSCRIPTIONS, sourceSubscriptionId, "upgrades")
-				.post(upgrade, UpgradeResult.class);
 	}
 }

--- a/src/main/java/org/springframework/social/partnercenter/api/order/subscription/upgrade/Upgrade.java
+++ b/src/main/java/org/springframework/social/partnercenter/api/order/subscription/upgrade/Upgrade.java
@@ -3,6 +3,7 @@ package org.springframework.social.partnercenter.api.order.subscription.upgrade;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.social.partnercenter.api.order.offer.Offer;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -12,7 +13,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 public class Upgrade {
 	private Offer targetOffer;
 	private UpgradeType upgradeType;
-	private boolean isEligible;
+	@JsonProperty("isEligible")
+	private boolean eligible;
 	private int quantity;
 	private List<UpgradeError> upgradeErrors;
 	private Map<String, String> attributes;
@@ -41,11 +43,11 @@ public class Upgrade {
 	}
 
 	public boolean isEligible() {
-		return isEligible;
+		return eligible;
 	}
 
 	public Upgrade setEligible(boolean eligible) {
-		isEligible = eligible;
+		this.eligible = eligible;
 		return this;
 	}
 


### PR DESCRIPTION
The upgrade operation needs the user+app context to perform
upgrade+license transfer which is the operation most often wanted for
such upgrade operations.