### PR TITLE
Fixing locale passed in X-Locale header

### DIFF
--- a/src/main/java/org/springframework/social/partnercenter/api/billing/pricing/impl/PricingTemplate.java
+++ b/src/main/java/org/springframework/social/partnercenter/api/billing/pricing/impl/PricingTemplate.java
@@ -36,7 +36,7 @@ public class PricingTemplate extends AbstractTemplate implements PricingOperatio
 		return restResource.request()
 				.queryParam("currency", currency)
 				.queryParam("region", region)
-				.header("X-Locale", locale.toString())
+				.header("X-Locale", locale.toLanguageTag())
 				.get(AzureResourcePricing.class);
 	}
 


### PR DESCRIPTION
We were sending Locale.toString() which is formatted as such (en_US) but the X-Locale header should take the languageTag (en-US)