### PR TITLE
Using refreshToken to refresh auth instead of resending username and password

### DIFF
--- a/release-notes-5.0.2.md
+++ b/release-notes-5.0.2.md
@@ -1,4 +1,0 @@
-## Release 5.0.2
-
-Bug Fixes
-1. Fixed serialization issue with date attributs in `org.springframework.social.partnercenter.api.order.subscription.Subscription` class.

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,0 +1,19 @@
+## 5.0.1
+This release changes several date fields to java.date types instead of _string_ and fixes bugs in UserOperations and PricingOperations
+
+#### Changes
+1. Changed **org.springframework.social.partnercenter.api.billing.pricing.AzureResourcePricing.locale** to **java.util.Locale** instead of **String**.
+1. Changed **org.springframework.social.partnercenter.api.billing.pricing.OfferTerm.effectiveDate** to **java.time.Instant** instead of **String**.
+1. Changed all of the following to **java.time.ZonedDateTime** instead of **String**.
+	* org.springframework.social.partnercenter.api.billing.pricing.PricingMeter.effectiveDate
+	* org.springframework.social.partnercenter.api.order.subscription.Subscription.creationDate
+	* org.springframework.social.partnercenter.api.order.subscription.Subscription.effectiveStartDate
+	* org.springframework.social.partnercenter.api.order.subscription.Subscription.commitmentEndDate
+1. Fixed bug passing Locale to **org.springframework.social.partnercenter.api.billing.pricing.PricingOperations. getAzurePricing**
+1. Fixed bug in **org.springframework.social.partnercenter.api.customer.user.AdminUserOperations.assignLicensesToUser**
+1. Changed parameter object for  **AdminUserOperations.assignLicensesToUser**. Previous contract was incorrect and lead to the aforementioned bug.
+
+## 5.0.2
+
+Bug Fixes
+1. Fixed serialization issue with date attributs in `org.springframework.social.partnercenter.api.order.subscription.Subscription` class.

--- a/src/main/java/org/springframework/social/partnercenter/connect/PartnerCenterConnectionFactory.java
+++ b/src/main/java/org/springframework/social/partnercenter/connect/PartnerCenterConnectionFactory.java
@@ -39,7 +39,7 @@ public class PartnerCenterConnectionFactory extends BasePartnerCenterConnectionF
 
 	public boolean canConnect(){
 		try {
-			createConnection();
+			createConnection().getApi().getCustomerOperations().getList(1);
 			return true;
 		} catch (Exception e){
 			return false;
@@ -48,7 +48,7 @@ public class PartnerCenterConnectionFactory extends BasePartnerCenterConnectionF
 
 	public boolean canConnect(String username, String password){
 		try {
-			createConnection(username, password);
+			createConnection(username, password).getApi().getCustomerOperations().getList(1);
 			return true;
 		} catch (Exception e) {
 			return false;
@@ -66,7 +66,8 @@ public class PartnerCenterConnectionFactory extends BasePartnerCenterConnectionF
 
 	public PartnerCenterAdminConnection createConnection(String username, String password){
 		AccessGrant accessGrant = getAuthOperations().exchangeCredentialsForAccess(username, password, new OAuth2Parameters());
-		return new PartnerCenterAdminConnection(getProviderId(), extractProviderUserId(accessGrant), username, password, accessGrant.getAccessToken(),
+
+		return new PartnerCenterAdminConnection(getProviderId(), extractProviderUserId(accessGrant), accessGrant.getRefreshToken(), accessGrant.getAccessToken(),
 				accessGrant.getExpireTime(), getPartnerCenterServiceProvider(), getApiAdapter());
 	}
 

--- a/src/main/java/org/springframework/social/partnercenter/connect/admin/AbstractUserConnection.java
+++ b/src/main/java/org/springframework/social/partnercenter/connect/admin/AbstractUserConnection.java
@@ -1,0 +1,15 @@
+package org.springframework.social.partnercenter.connect.admin;
+
+import org.springframework.social.connect.ApiAdapter;
+import org.springframework.social.connect.ConnectionData;
+import org.springframework.social.connect.support.AbstractConnection;
+
+public abstract class AbstractUserConnection<A> extends AbstractConnection<A> implements UserConnection<A> {
+	public AbstractUserConnection(ApiAdapter<A> apiAdapter) {
+		super(apiAdapter);
+	}
+
+	public AbstractUserConnection(ConnectionData data, ApiAdapter<A> apiAdapter) {
+		super(data, apiAdapter);
+	}
+}

--- a/src/main/java/org/springframework/social/partnercenter/connect/admin/PartnerCenterAdminConnection.java
+++ b/src/main/java/org/springframework/social/partnercenter/connect/admin/PartnerCenterAdminConnection.java
@@ -18,19 +18,18 @@ import org.springframework.social.partnercenter.security.PartnerCenterServicePro
 public class PartnerCenterAdminConnection extends AbstractConnection<PartnerCenter> {
 
 	private String accessToken;
+	private String refreshToken;
 	private Long expireTime;
-	private String username;
-	private String password;
 	private transient final PartnerCenterServiceProvider serviceProvider;
 
 	private transient PartnerCenterAdmin adminApi;
 
 	private transient PartnerCenterAdmin adminApiProxy;
 
-	public PartnerCenterAdminConnection(String providerId, String providerUserId, String username, String password, String accessToken, Long expireTime, PartnerCenterServiceProvider serviceProvider, ApiAdapter<PartnerCenter> apiAdapter) {
+	public PartnerCenterAdminConnection(String providerId, String providerUserId, String refreshToken, String accessToken, Long expireTime, PartnerCenterServiceProvider serviceProvider, ApiAdapter<PartnerCenter> apiAdapter) {
 		super(apiAdapter);
 		this.serviceProvider = serviceProvider;
-		initAccessAttributes(accessToken, expireTime, username, password);
+		initAccessAttributes(accessToken, expireTime, refreshToken);
 		initApi();
 		initApiProxy();
 		initKey(providerId, providerUserId);
@@ -43,8 +42,8 @@ public class PartnerCenterAdminConnection extends AbstractConnection<PartnerCent
 	@Override
 	public void refresh() {
 		synchronized (getMonitor()) {
-			AccessGrant accessGrant = serviceProvider.getAzureADAuthOperations().exchangeCredentialsForAccess(username, password, new OAuth2Parameters());
-			initAccessAttributes(accessGrant.getAccessToken(), accessGrant.getExpireTime(), this.username, this.password);
+			AccessGrant accessGrant = serviceProvider.getAzureADAuthOperations().refreshAccess(refreshToken, new OAuth2Parameters());
+			initAccessAttributes(accessGrant.getAccessToken(), accessGrant.getExpireTime(), accessGrant.getRefreshToken());
 			initApi();
 		}
 	}
@@ -74,11 +73,10 @@ public class PartnerCenterAdminConnection extends AbstractConnection<PartnerCent
 		}
 	}
 
-	private void initAccessAttributes(String accessToken, Long expireTime, String username, String password) {
+	private void initAccessAttributes(String accessToken, Long expireTime, String refreshToken) {
 		this.accessToken = accessToken;
 		this.expireTime = expireTime;
-		this.username = username;
-		this.password = password;
+		this.refreshToken = refreshToken;
 	}
 
 

--- a/src/main/java/org/springframework/social/partnercenter/connect/admin/PartnerCenterAdminConnection.java
+++ b/src/main/java/org/springframework/social/partnercenter/connect/admin/PartnerCenterAdminConnection.java
@@ -8,14 +8,13 @@ import java.lang.reflect.Proxy;
 import org.springframework.social.ExpiredAuthorizationException;
 import org.springframework.social.connect.ApiAdapter;
 import org.springframework.social.connect.ConnectionData;
-import org.springframework.social.connect.support.AbstractConnection;
 import org.springframework.social.oauth2.AccessGrant;
 import org.springframework.social.oauth2.OAuth2Parameters;
 import org.springframework.social.partnercenter.PartnerCenter;
 import org.springframework.social.partnercenter.PartnerCenterAdmin;
 import org.springframework.social.partnercenter.security.PartnerCenterServiceProvider;
 
-public class PartnerCenterAdminConnection extends AbstractConnection<PartnerCenter> {
+public class PartnerCenterAdminConnection extends AbstractUserConnection<PartnerCenter> {
 
 	private String accessToken;
 	private String refreshToken;
@@ -43,6 +42,15 @@ public class PartnerCenterAdminConnection extends AbstractConnection<PartnerCent
 	public void refresh() {
 		synchronized (getMonitor()) {
 			AccessGrant accessGrant = serviceProvider.getAzureADAuthOperations().refreshAccess(refreshToken, new OAuth2Parameters());
+			initAccessAttributes(accessGrant.getAccessToken(), accessGrant.getExpireTime(), accessGrant.getRefreshToken());
+			initApi();
+		}
+	}
+
+	@Override
+	public void refresh(String username, String password) {
+		synchronized (getMonitor()) {
+			AccessGrant accessGrant = serviceProvider.getAzureADAuthOperations().exchangeCredentialsForAccess(username, password, new OAuth2Parameters());
 			initAccessAttributes(accessGrant.getAccessToken(), accessGrant.getExpireTime(), accessGrant.getRefreshToken());
 			initApi();
 		}

--- a/src/main/java/org/springframework/social/partnercenter/connect/admin/UserConnection.java
+++ b/src/main/java/org/springframework/social/partnercenter/connect/admin/UserConnection.java
@@ -1,0 +1,15 @@
+package org.springframework.social.partnercenter.connect.admin;
+
+import org.springframework.social.connect.Connection;
+
+public interface UserConnection<A> extends Connection<A>{
+	/**
+	 * Refresh this connection.
+	 * Used to renew an expired connection.
+	 * If the refresh operation is successful, {@link #hasExpired()} returns false.
+	 * Not supported by all connection implementations; if not supported, this method is a no-op.
+	 * @param username username to use for authentication
+	 * @param password password to be used for authentication
+	 */
+	void refresh(String username, String password);
+}

--- a/src/main/java/org/springframework/social/partnercenter/security/AzureADAuthOperations.java
+++ b/src/main/java/org/springframework/social/partnercenter/security/AzureADAuthOperations.java
@@ -28,13 +28,20 @@ public interface AzureADAuthOperations {
 	 */
 	AccessGrant exchangeCredentialsForAccess(String username, String password, MultiValueMap<String, String> additionalParameters);
 
-
 	/**
 	 * Refreshes a previous access grant.
 	 * @param additionalParameters any additional parameters to be sent when refreshing a previous access grant. Should not be encoded.
 	 * @return the access grant.
 	 */
 	AccessGrant refreshAccess(MultiValueMap<String, String> additionalParameters);
+
+	/**
+	 * Refreshes a previous access grant.
+	 * @param refreshToken the refresh token from the previous access grant.
+	 * @param additionalParameters any additional parameters to be sent when refreshing a previous access grant. Should not be encoded.
+	 * @return the access grant.
+	 */
+	AccessGrant refreshAccess(String refreshToken, MultiValueMap<String, String> additionalParameters);
 
 	/**
 	 * adds request and response logging to restTemplate

--- a/src/main/java/org/springframework/social/partnercenter/security/AzureADAuthTemplate.java
+++ b/src/main/java/org/springframework/social/partnercenter/security/AzureADAuthTemplate.java
@@ -198,6 +198,21 @@ public class AzureADAuthTemplate implements AzureADAuthOperations {
 	}
 
 	@Override
+	public AccessGrant refreshAccess(String refreshToken, MultiValueMap<String, String> additionalParameters) {
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		if (useParametersForClientAuthentication) {
+			params.set("client_id", nativeAppId);
+		}
+		params.set("refresh_token", refreshToken);
+		params.set("grant_type", "refresh_token");
+		params.set("scope", "openid");
+		if (additionalParameters != null) {
+			params.putAll(additionalParameters);
+		}
+		return postForAccessGrant(accessTokenUrl, params);
+	}
+
+	@Override
 	public void enableSlf4j(LogLevel logLevel) {
 		HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
 		BufferingClientHttpRequestFactory requestFactory = new BufferingClientHttpRequestFactory(factory);


### PR DESCRIPTION


By making this change we no longer need to keep the username and password in the 'Connection' object. We will instead keep only the refresh token received in the previous exchange for credentials