### PR TITLE
fixing auth exceptions to wrap as ApiAuthorizationException

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,6 +1,12 @@
 # Release Notes: Spring Social for Microsoft Partner Center
 
+## 6.2.1
+
+#### Bug Fixes
+1. Fixed AuthorizationTemplate to ensure failed rest calls get wrapped as ApiAuthorizationException.
+
 ## 6.2.0
+
 #### Added
 1. ServiceRequestOperations added to allow for creating and retrieving service requests through the API
 

--- a/src/main/java/org/springframework/social/partnercenter/security/AzureADAuthTemplate.java
+++ b/src/main/java/org/springframework/social/partnercenter/security/AzureADAuthTemplate.java
@@ -247,7 +247,11 @@ public class AzureADAuthTemplate implements AzureADAuthOperations {
 	protected AccessGrant postForAccessGrant(String accessTokenUrl, HttpHeaders headers, MultiValueMap<String, String> parameters) {
 		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(parameters, headers);
-		return extractAccessGrant(getRestTemplate().postForObject(accessTokenUrl, request, Map.class));
+		try {
+			return extractAccessGrant(getRestTemplate().postForObject(accessTokenUrl, request, Map.class));
+		} catch (HttpStatusCodeException e) {
+			throw buildAuthFault(e);
+		}
 	}
 
 	/**
@@ -265,8 +269,11 @@ public class AzureADAuthTemplate implements AzureADAuthOperations {
 	protected AccessGrant postForAccessGrant(String accessTokenUrl, MultiValueMap<String, String> parameters) {
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-		return extractAccessGrant(getRestTemplate().postForObject(accessTokenUrl, new HttpEntity<>(parameters, headers), Map.class));
+		try {
+			return extractAccessGrant(getRestTemplate().postForObject(accessTokenUrl, new HttpEntity<>(parameters, headers), Map.class));
+		} catch (HttpStatusCodeException e) {
+			throw buildAuthFault(e);
+		}
 	}
 
 	private AzureADSecurityToken postForADToken(){


### PR DESCRIPTION
Several calls in the AzureADAuthTemplate we not being wrapped correctly