### PR TITLE
Adding the patch releases to the travis release bash script

### DIFF
--- a/.travis/scripts/travis-release.sh
+++ b/.travis/scripts/travis-release.sh
@@ -15,7 +15,16 @@ then
 elif [[ ${last_merged_pr_branch} =~ ^release/.* ]];
 then
 	echo "Creating Patch Release"
-	gradle release -Prelease.disableChecks -Prelease.pushTagsOnly -Prelease.customKeyFile=".travis/id_rsa_partner_center.dec" -Prelease.versionIncrementer=incrementPatch -s;
+	if [[ ${last_merged_pr_branch} =~ ^release/patch/.* ]];
+	then
+		patch_pattern="release/patch/"
+		new_release=${last_merged_pr_branch/release\/patch\/""}
+		gradle release -Prelease.disableChecks -Prelease.pushTagsOnly -Prelease.customKeyFile=".travis/id_rsa_partner_center.dec" -Prelease.version=${new_release} -s
+	else
+		gradle release -Prelease.disableChecks -Prelease.pushTagsOnly -Prelease.customKeyFile=".travis/id_rsa_partner_center.dec" -Prelease.versionIncrementer=incrementPatch -s;
+	fi
 else
 	echo "Release Regex not matched. No release will be built."
 fi
+
+


### PR DESCRIPTION
This will allow us to make patch releases on previous versions without having to release manually