### PR TITLE
Add operations related to Customer Cloud Agreement

### DIFF
--- a/src/main/java/org/springframework/social/partnercenter/PartnerCenter.java
+++ b/src/main/java/org/springframework/social/partnercenter/PartnerCenter.java
@@ -3,6 +3,7 @@ package org.springframework.social.partnercenter;
 import java.util.Locale;
 
 import org.springframework.social.ApiBinding;
+import org.springframework.social.partnercenter.api.agreement.AgreementOperations;
 import org.springframework.social.partnercenter.api.analytics.AnalyticsOperations;
 import org.springframework.social.partnercenter.api.audit.AuditOperations;
 import org.springframework.social.partnercenter.api.billing.invoicing.InvoiceOperations;
@@ -41,6 +42,7 @@ public interface PartnerCenter extends ApiBinding {
 	DirectoryRoleOperations getDirectoryRoleOperations();
 	RoleOperations getRoleOperations();
 	ConsentOperations getConsentOperations();
+	AgreementOperations getAgreementOperations();
 	void enableSlf4j(LogLevel level);
 	void setLocale(Locale locale);
 	boolean isSlf4jEnabled();

--- a/src/main/java/org/springframework/social/partnercenter/api/PartnerCenterTemplate.java
+++ b/src/main/java/org/springframework/social/partnercenter/api/PartnerCenterTemplate.java
@@ -9,6 +9,8 @@ import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.social.oauth2.AbstractOAuth2ApiBinding;
 import org.springframework.social.partnercenter.PartnerCenter;
+import org.springframework.social.partnercenter.api.agreement.AgreementOperations;
+import org.springframework.social.partnercenter.api.agreement.AgreementTemplate;
 import org.springframework.social.partnercenter.api.analytics.AnalyticsOperations;
 import org.springframework.social.partnercenter.api.analytics.impl.AnalyticsTemplate;
 import org.springframework.social.partnercenter.api.audit.AuditOperations;
@@ -73,8 +75,9 @@ public class PartnerCenterTemplate extends AbstractOAuth2ApiBinding implements P
 	private final DirectoryRoleOperations directoryRoleOperations;
 	private final RoleOperations roleOperations;
 	private final ConsentOperations consentOperations;
+	private final AgreementOperations agreementOperations;
 
-	public PartnerCenterTemplate(UriProvider uriProvider, String accessToken, String version){
+	public PartnerCenterTemplate(UriProvider uriProvider, String accessToken, String version) {
 		super(accessToken);
 		addVersionInterceptor(version);
 		this.uriProvider = uriProvider;
@@ -122,6 +125,9 @@ public class PartnerCenterTemplate extends AbstractOAuth2ApiBinding implements P
 		roleOperations = new RoleTemplate(createRestResource(uriProvider.partnerBaseUri().build().toUri()), isAuthorized());
 
 		consentOperations = new ConsentTemplate(createRestResource(uriProvider.partnerCenterCustomerUri().build().toUri()), isAuthorized());
+
+		agreementOperations = new AgreementTemplate(createRestResource(
+				uriProvider.partnerCenterBuilder().pathSegment("v1").build().toUri()), isAuthorized());
 	}
 
 	private RestResource createRestResource(URI baseUri){
@@ -223,6 +229,11 @@ public class PartnerCenterTemplate extends AbstractOAuth2ApiBinding implements P
 	@Override
 	public ConsentOperations getConsentOperations() {
 		return consentOperations;
+	}
+
+	@Override
+	public AgreementOperations getAgreementOperations() {
+		return agreementOperations;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/social/partnercenter/api/agreement/Agreement.java
+++ b/src/main/java/org/springframework/social/partnercenter/api/agreement/Agreement.java
@@ -1,0 +1,68 @@
+package org.springframework.social.partnercenter.api.agreement;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import java.time.Instant;
+
+import org.springframework.social.partnercenter.api.profile.Contact;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(NON_NULL)
+public class Agreement {
+
+	private String userId;
+	private Contact primaryContact;
+	private Instant dateAgreed;
+	private String templateId;
+	private AgreementType type;
+	private String agreementLink;
+
+	public String getUserId() {
+		return userId;
+	}
+
+	public void setUserId(String userId) {
+		this.userId = userId;
+	}
+
+	public Contact getPrimaryContact() {
+		return primaryContact;
+	}
+
+	public void setPrimaryContact(Contact primaryContact) {
+		this.primaryContact = primaryContact;
+	}
+
+	public Instant getDateAgreed() {
+		return dateAgreed;
+	}
+
+	public void setDateAgreed(Instant dateAgreed) {
+		this.dateAgreed = dateAgreed;
+	}
+
+	public String getTemplateId() {
+		return templateId;
+	}
+
+	public void setTemplateId(String templateId) {
+		this.templateId = templateId;
+	}
+
+	public AgreementType getType() {
+		return type;
+	}
+
+	public void setType(AgreementType type) {
+		this.type = type;
+	}
+
+	public String getAgreementLink() {
+		return agreementLink;
+	}
+
+	public void setAgreementLink(String agreementLink) {
+		this.agreementLink = agreementLink;
+	}
+}

--- a/src/main/java/org/springframework/social/partnercenter/api/agreement/AgreementMetaData.java
+++ b/src/main/java/org/springframework/social/partnercenter/api/agreement/AgreementMetaData.java
@@ -1,0 +1,46 @@
+package org.springframework.social.partnercenter.api.agreement;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(NON_NULL)
+public class AgreementMetaData {
+
+	private String templateId;
+	private AgreementType agreementType;
+	private String agreementLink;
+	private Integer versionRank;
+
+	public String getTemplateId() {
+		return templateId;
+	}
+
+	public void setTemplateId(String templateId) {
+		this.templateId = templateId;
+	}
+
+	public AgreementType getAgreementType() {
+		return agreementType;
+	}
+
+	public void setAgreementType(AgreementType agreementType) {
+		this.agreementType = agreementType;
+	}
+
+	public String getAgreementLink() {
+		return agreementLink;
+	}
+
+	public void setAgreementLink(String agreementLink) {
+		this.agreementLink = agreementLink;
+	}
+
+	public Integer getVersionRank() {
+		return versionRank;
+	}
+
+	public void setVersionRank(Integer versionRank) {
+		this.versionRank = versionRank;
+	}
+}

--- a/src/main/java/org/springframework/social/partnercenter/api/agreement/AgreementOperations.java
+++ b/src/main/java/org/springframework/social/partnercenter/api/agreement/AgreementOperations.java
@@ -1,0 +1,11 @@
+package org.springframework.social.partnercenter.api.agreement;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.social.partnercenter.api.PagingResourceOperations;
+import org.springframework.social.partnercenter.api.PartnerCenterResponse;
+
+public interface AgreementOperations extends PagingResourceOperations<AgreementMetaData> {
+	ResponseEntity<PartnerCenterResponse<AgreementMetaData>> getAgreementMetadatas();
+	ResponseEntity<Agreement> confirmCustomerAcceptance(String customerTenantId, Agreement agreement);
+	ResponseEntity<PartnerCenterResponse<Agreement>> getConfirmations(String customerTenantId);
+}

--- a/src/main/java/org/springframework/social/partnercenter/api/agreement/AgreementTemplate.java
+++ b/src/main/java/org/springframework/social/partnercenter/api/agreement/AgreementTemplate.java
@@ -1,0 +1,42 @@
+package org.springframework.social.partnercenter.api.agreement;
+
+import static org.springframework.social.partnercenter.api.validation.Assertion.notNull;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.ResponseEntity;
+import org.springframework.social.partnercenter.api.PagingResourceTemplate;
+import org.springframework.social.partnercenter.api.PartnerCenterResponse;
+import org.springframework.social.partnercenter.http.client.RestResource;
+
+public class AgreementTemplate extends PagingResourceTemplate<AgreementMetaData> implements AgreementOperations {
+	private RestResource restResource;
+
+	public AgreementTemplate(RestResource restResource, boolean isAuthorized) {
+		super(restResource, isAuthorized, new ParameterizedTypeReference<PartnerCenterResponse<AgreementMetaData>>() {});
+		this.restResource = restResource;
+	}
+
+	@Override
+	public ResponseEntity<PartnerCenterResponse<AgreementMetaData>> getAgreementMetadatas() {
+		return restResource.request()
+				.pathSegment("agreements")
+				.get(new ParameterizedTypeReference<PartnerCenterResponse<AgreementMetaData>>() {});
+	}
+
+	@Override
+	public ResponseEntity<Agreement> confirmCustomerAcceptance(String customerTenantId, Agreement agreement) {
+		notNull(customerTenantId, "customerTenantId");
+		notNull(agreement, "agreement");
+		return restResource.request()
+				.pathSegment("customers", customerTenantId, "agreements")
+				.post(agreement, Agreement.class);
+	}
+
+	@Override
+	public ResponseEntity<PartnerCenterResponse<Agreement>> getConfirmations(String customerTenantId) {
+		notNull(customerTenantId, "customerTenantId");
+		return restResource.request()
+				.pathSegment("customers", customerTenantId, "agreements")
+				.get(new ParameterizedTypeReference<PartnerCenterResponse<Agreement>>() {});
+	}
+}

--- a/src/main/java/org/springframework/social/partnercenter/api/agreement/AgreementType.java
+++ b/src/main/java/org/springframework/social/partnercenter/api/agreement/AgreementType.java
@@ -1,0 +1,18 @@
+package org.springframework.social.partnercenter.api.agreement;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum AgreementType {
+	MICROSOFT_CLOUD_AGREEMENT("MicrosoftCloudAgreement");
+
+	private String jsonValue;
+
+	AgreementType(String jsonValue) {
+		this.jsonValue = jsonValue;
+	}
+
+	@JsonValue
+	public String jsonValue() {
+		return jsonValue;
+	}
+}

--- a/src/test/java/org/springframework/social/partnercenter/api/agreement/AgreementOperationsTest.java
+++ b/src/test/java/org/springframework/social/partnercenter/api/agreement/AgreementOperationsTest.java
@@ -1,0 +1,114 @@
+package org.springframework.social.partnercenter.api.agreement;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static java.time.Instant.now;
+import static java.time.Instant.parse;
+import static org.springframework.social.partnercenter.api.agreement.AgreementType.MICROSOFT_CLOUD_AGREEMENT;
+import static org.springframework.social.partnercenter.test.stubs.AgreementOperationStubs.given_confirmCustomerAcceptance_201_Created;
+import static org.springframework.social.partnercenter.test.stubs.AgreementOperationStubs.given_getAgreementMetadata_200_OK;
+import static org.springframework.social.partnercenter.test.stubs.AgreementOperationStubs.given_getConfirmations_200_OK;
+import static org.springframework.social.partnercenter.test.stubs.StubURI.baseURI;
+import static org.springframework.social.partnercenter.test.stubs.TestRestTemplateFactory.createRestTemplate;
+import static org.springframework.social.partnercenter.test.utils.UUIDUtils.createUUIDAsString;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.springframework.social.partnercenter.api.PartnerCenterResponse;
+import org.springframework.social.partnercenter.api.profile.Contact;
+import org.springframework.social.partnercenter.http.client.RestClient;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+public class AgreementOperationsTest {
+
+	@Rule
+	public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
+
+	@Test
+	public void getAgreementMetadatas_whenCalled_thenResponseIsParsedCorrectly() {
+		given_getAgreementMetadata_200_OK();
+
+		AgreementOperations agreementOperations = new AgreementTemplate(new RestClient(createRestTemplate(),
+		                                                                               baseURI(wireMockRule.port(), "v1")),
+		                                                                true);
+
+		PartnerCenterResponse<AgreementMetaData> res = agreementOperations.getAgreementMetadatas().getBody();
+
+		SoftAssertions.assertSoftly(softly -> {
+			softly.assertThat(res.getItems()).hasSize(1);
+
+			AgreementMetaData agreementMetaData = res.getItems().get(0);
+			softly.assertThat(agreementMetaData.getTemplateId()).isEqualTo("00001111-2222-3333-4444-555566667777");
+			softly.assertThat(agreementMetaData.getAgreementType()).isEqualTo(MICROSOFT_CLOUD_AGREEMENT);
+			softly.assertThat(agreementMetaData.getAgreementLink()).isEqualTo("https://domain.com");
+			softly.assertThat(agreementMetaData.getVersionRank()).isEqualTo(0);
+		});
+	}
+
+	@Test
+	public void confirmCustomerAcceptance_whenCalled_thenResponseIsParsedCorrectly() {
+		Agreement givenAgreement = anAgreement();
+		given_confirmCustomerAcceptance_201_Created(givenAgreement);
+
+		AgreementOperations agreementOperations = new AgreementTemplate(new RestClient(createRestTemplate(),
+		                                                                               baseURI(wireMockRule.port(), "v1")),
+		                                                                true);
+
+		Agreement agreement = agreementOperations.confirmCustomerAcceptance("tenantId", givenAgreement).getBody();
+
+		SoftAssertions.assertSoftly(softly -> {
+			softly.assertThat(agreement.getUserId()).isEqualTo(givenAgreement.getUserId());
+			softly.assertThat(agreement.getPrimaryContact()).isEqualToComparingFieldByFieldRecursively(givenAgreement.getPrimaryContact());
+			softly.assertThat(agreement.getDateAgreed()).isEqualTo(givenAgreement.getDateAgreed());
+			softly.assertThat(agreement.getTemplateId()).isEqualTo(givenAgreement.getTemplateId());
+			softly.assertThat(agreement.getType()).isEqualTo(givenAgreement.getType());
+			softly.assertThat(agreement.getAgreementLink()).isEqualTo(givenAgreement.getAgreementLink());
+		});
+	}
+
+	@Test
+	public void getConfirmations_whenCalled_thenResponseIsParsedCorrectly() {
+		given_getConfirmations_200_OK();
+
+		AgreementOperations agreementOperations = new AgreementTemplate(new RestClient(createRestTemplate(),
+		                                                                               baseURI(wireMockRule.port(), "v1")),
+		                                                                true);
+
+		PartnerCenterResponse<Agreement> res = agreementOperations.getConfirmations("tenantId").getBody();
+
+		SoftAssertions.assertSoftly(softly -> {
+			softly.assertThat(res.getItems()).hasSize(1);
+
+			Agreement agreement = res.getItems().get(0);
+			softly.assertThat(agreement.getTemplateId()).isEqualTo("00001111-2222-3333-4444-555566667777");
+			softly.assertThat(agreement.getDateAgreed()).isEqualTo(parse("2018-10-01T00:00:00.123Z"));
+			softly.assertThat(agreement.getType()).isEqualTo(MICROSOFT_CLOUD_AGREEMENT);
+			softly.assertThat(agreement.getAgreementLink()).isEqualTo("https://domain.com");
+
+			Contact primaryContact = agreement.getPrimaryContact();
+			softly.assertThat(primaryContact).isNotNull();
+			softly.assertThat(primaryContact.getFirstName()).isEqualTo("John");
+			softly.assertThat(primaryContact.getLastName()).isEqualTo("Doe");
+			softly.assertThat(primaryContact.getEmail()).isEqualTo("john.doe@domain.com");
+			softly.assertThat(primaryContact.getPhoneNumber()).isEqualTo("1234567890");
+		});
+	}
+
+	private Agreement anAgreement() {
+		Agreement agreement = new Agreement();
+		agreement.setUserId(createUUIDAsString(1));
+		agreement.setDateAgreed(now());
+		agreement.setTemplateId(createUUIDAsString(2));
+		agreement.setType(MICROSOFT_CLOUD_AGREEMENT);
+
+		Contact contact = new Contact();
+		contact.setFirstName("John");
+		contact.setLastName("Doe");
+		contact.setEmail("john.doe@domain.com");
+		contact.setPhoneNumber("5551234567");
+		agreement.setPrimaryContact(contact);
+
+		return agreement;
+	}
+}

--- a/src/test/java/org/springframework/social/partnercenter/test/stubs/AgreementOperationStubs.java
+++ b/src/test/java/org/springframework/social/partnercenter/test/stubs/AgreementOperationStubs.java
@@ -1,0 +1,40 @@
+package org.springframework.social.partnercenter.test.stubs;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import org.springframework.social.partnercenter.api.agreement.Agreement;
+import org.springframework.social.partnercenter.serialization.JsonConverter;
+import org.springframework.social.partnercenter.test.Resource;
+
+public class AgreementOperationStubs {
+
+	public static void given_getAgreementMetadata_200_OK() {
+		stubFor(get(anyUrl())
+				        .willReturn(aResponse()
+						                    .withStatus(200)
+						                    .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+						                    .withBody(Resource.parseFile("data/agreement/get-agreement-metadata.json").getAsString())));
+	}
+
+	public static void given_confirmCustomerAcceptance_201_Created(Agreement agreement) {
+		stubFor(post(anyUrl())
+				        .willReturn(aResponse()
+						                    .withStatus(200)
+						                    .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+						                    .withBody(new JsonConverter().toJson(agreement))));
+	}
+
+	public static void given_getConfirmations_200_OK() {
+		stubFor(get(anyUrl())
+				        .willReturn(aResponse()
+						                    .withStatus(200)
+						                    .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+						                    .withBody(Resource.parseFile("data/agreement/get-confirmations.json").getAsString())));
+	}
+}

--- a/src/test/resources/data/agreement/get-agreement-metadata.json
+++ b/src/test/resources/data/agreement/get-agreement-metadata.json
@@ -1,0 +1,21 @@
+{
+  "totalCount": 1,
+  "items": [
+    {
+      "templateId": "00001111-2222-3333-4444-555566667777",
+      "agreementType": "MicrosoftCloudAgreement",
+      "agreementLink": "https://domain.com",
+      "versionRank": 0
+    }
+  ],
+  "links": {
+    "self": {
+      "uri": "/agreements",
+      "method": "GET",
+      "headers": []
+    }
+  },
+  "attributes": {
+    "objectType": "Collection"
+  }
+}

--- a/src/test/resources/data/agreement/get-confirmations.json
+++ b/src/test/resources/data/agreement/get-confirmations.json
@@ -1,0 +1,19 @@
+{
+  "totalCount": 1,
+  "items":
+  [
+    {
+      "primaryContact":
+      {
+        "firstName":"John",
+        "lastName":"Doe",
+        "email":"john.doe@domain.com",
+        "phoneNumber":"1234567890"
+      },
+      "templateId":"00001111-2222-3333-4444-555566667777",
+      "dateAgreed":"2018-10-01T00:00:00.123Z",
+      "type":"MicrosoftCloudAgreement",
+      "agreementLink":"https://domain.com"
+    }
+  ]
+}


### PR DESCRIPTION
Implemented operations:
- [Get agreements](https://docs.microsoft.com/en-us/partner-center/develop/get-agreement-metadata): `ResponseEntity<PartnerCenterResponse<AgreementMetaData>> getAgreementMetadata()`
- [Confirm consent](https://docs.microsoft.com/en-us/partner-center/develop/confirm-customer-consent): `ResponseEntity<PartnerCenterResponse<Agreement>> getCustomerAcceptance(String customerTenantId)`
- [Get confirmation consents](https://docs.microsoft.com/en-us/partner-center/develop/get-confirmation-of-customer-consent): `ResponseEntity<Agreement> confirmCustomerAcceptance(String customerTenantId, Agreement agreement);`

Resources created from docs:
- `AgreementMetaData`: https://docs.microsoft.com/en-us/partner-center/develop/agreement-metadata
- `Agreement`: https://docs.microsoft.com/en-us/partner-center/develop/agreement-metadata

Notes:
- The [Get agreements](https://docs.microsoft.com/en-us/partner-center/develop/get-agreement-metadata) operation is supposed to return a collection of [AgreementMetaData](https://docs.microsoft.com/en-us/partner-center/develop/agreement-metadata): among the fields returned by the operation, instead of `type` it returns `agreementType`!
- The [Confirm consent](https://docs.microsoft.com/en-us/partner-center/develop/confirm-customer-consent) operation can accept multiple date time format, which in the response might be different, examples:
  - If input is `2018-10-01`, then the response will be `2018-10-01T00:00:00`
  - If input is `2018-10-01T00:00:00`, then the response will be `2018-10-01T00:00:00`
  - If input is `2018-10-01T00:00:00+02:00`, then the response will be `2018-09-30T22:00:00+00:00`
  - If input is `2018-10-01T00:00:00Z`, then the response will be `2018-10-01T00:00:00Z` <-
  - If input is `2018-10-01T00:00:00.123Z`, then the response will be `2018-10-01T00:00:00.123Z` <-

**The current implementation will only support an Instant as date time object (output will be _2018-10-01T00:00:00[.000]Z_** as expected by the API doc.