### PR TITLE
Fix loss of precision when importing Azure Pricing Rates

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,9 @@
 # Release Notes: Spring Social for Microsoft Partner Center
 
+## 9.0.0
+#### Changed
+- Change data type for rates in the `PricingMeter` class to use `BigDecimal` instead of `double` to avoid loss of precision with large number of decimals
+
 ## 8.0.2
 #### Changed
 - Change `dateAgreed` type from `Instant` to `String` due to API inconsistencies

--- a/src/main/java/org/springframework/social/partnercenter/api/billing/pricing/PricingMeter.java
+++ b/src/main/java/org/springframework/social/partnercenter/api/billing/pricing/PricingMeter.java
@@ -1,5 +1,6 @@
 package org.springframework.social.partnercenter.api.billing.pricing;
 
+import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
@@ -11,7 +12,7 @@ public class PricingMeter {
 	private String id;
 	private String name;
 	private List<String> tags;
-	private Map<String, Double> rates;
+	private Map<String, BigDecimal> rates;
 	private String category;
 	private String subcategory;
 	private String region;
@@ -46,11 +47,11 @@ public class PricingMeter {
 		return this;
 	}
 
-	public Map<String, Double> getRates() {
+	public Map<String, BigDecimal> getRates() {
 		return rates;
 	}
 
-	public PricingMeter setRates(Map<String, Double> rates) {
+	public PricingMeter setRates(Map<String, BigDecimal> rates) {
 		this.rates = rates;
 		return this;
 	}

--- a/src/test/java/org/springframework/social/partnercenter/api/analytics/AnalyticsOperationsTest.java
+++ b/src/test/java/org/springframework/social/partnercenter/api/analytics/AnalyticsOperationsTest.java
@@ -1,5 +1,6 @@
 package org.springframework.social.partnercenter.api.analytics;
 
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.springframework.social.partnercenter.test.stubs.AnalyticsOperationStubs.given_getPartnerLicensesDeploymentInsights_200_OK;
 import static org.springframework.social.partnercenter.test.stubs.AnalyticsOperationStubs.given_getPartnerLicensesUsageInsights_200_OK;
 import static org.springframework.social.partnercenter.test.stubs.TestURIs.baseURI;
@@ -12,19 +13,20 @@ import org.junit.Test;
 import org.springframework.social.partnercenter.api.PartnerCenterResponse;
 import org.springframework.social.partnercenter.api.analytics.impl.AnalyticsTemplate;
 import org.springframework.social.partnercenter.http.client.RestClient;
+import org.springframework.social.partnercenter.test.stubs.StubURI;
 import org.springframework.social.partnercenter.test.stubs.TestRestTemplateFactory;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
 public class AnalyticsOperationsTest {
 	@Rule
-	public WireMockRule wireMockRule = new WireMockRule();
+	public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
 
 	@Test
 	public void testGetPartnerLicensesDeploymentInsights() {
 		given_getPartnerLicensesDeploymentInsights_200_OK();
 
-		final AnalyticsOperations analyticsOperations = new AnalyticsTemplate(new RestClient(TestRestTemplateFactory.createRestTemplate(), baseURI("v1")), true);
+		final AnalyticsOperations analyticsOperations = new AnalyticsTemplate(new RestClient(TestRestTemplateFactory.createRestTemplate(), StubURI.baseURI(wireMockRule.port(), "v1")), true);
 		final PartnerCenterResponse<PartnerLicensesDeploymentInsights> insightsPartnerCenterResponse = analyticsOperations.getPartnerLicensesDeploymentInsights().getBody();
 
 		SoftAssertions.assertSoftly(softly -> {
@@ -47,7 +49,7 @@ public class AnalyticsOperationsTest {
 	public void testGetPartnerLicensesUsageInsights() {
 		given_getPartnerLicensesUsageInsights_200_OK();
 
-		final AnalyticsOperations analyticsOperations = new AnalyticsTemplate(new RestClient(TestRestTemplateFactory.createRestTemplate(), baseURI("v1")), true);
+		final AnalyticsOperations analyticsOperations = new AnalyticsTemplate(new RestClient(TestRestTemplateFactory.createRestTemplate(), StubURI.baseURI(wireMockRule.port(), "v1")), true);
 		final PartnerCenterResponse<PartnerLicensesUsageInsights> insightsPartnerCenterResponse = analyticsOperations.getPartnerLicensesUsageInsights().getBody();
 
 		SoftAssertions.assertSoftly(softly -> {

--- a/src/test/java/org/springframework/social/partnercenter/api/billing/pricing/PricingOperationsTest.java
+++ b/src/test/java/org/springframework/social/partnercenter/api/billing/pricing/PricingOperationsTest.java
@@ -1,11 +1,14 @@
 package org.springframework.social.partnercenter.api.billing.pricing;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.springframework.social.partnercenter.test.stubs.PricingOperationsStubs.given_getAzurePricingForCurrencyAndRegion_returningRealRates;
 import static org.springframework.social.partnercenter.test.stubs.PricingOperationsStubs.given_getAzurePricing_200_OK;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Locale;
+import java.util.stream.IntStream;
 
 import org.assertj.core.api.SoftAssertions;
 import org.junit.Rule;
@@ -33,7 +36,24 @@ public class PricingOperationsTest {
 			softly.assertThat(azurePricing.getBody().getMeters().get(0).getEffectiveDate()).isEqualTo(ZonedDateTime.parse("2015-10-01T00:00:00Z"));
 			softly.assertThat(azurePricing.getBody().getMeters().get(1).getEffectiveDate()).isEqualTo(ZonedDateTime.parse("2015-11-01T00:00:00Z"));
 			softly.assertThat(azurePricing.getBody().getLocale()).isEqualTo(Locale.US);
+		});
+	}
 
+	@Test
+	public void testGetAzurePricingWithCountryAndLocale_whenCalled_thenResponseIsParsedCorrectlyWithComplexRates() {
+		given_getAzurePricingForCurrencyAndRegion_returningRealRates("EUR", "DE");
+
+		final PricingTemplate pricingTemplate = new PricingTemplate(new RestClient(TestRestTemplateFactory.createRestTemplate(), StubURI.baseURI(wireMockRule.port(), "v1", "ratecards", "azure")), true);
+		final ResponseEntity<AzureResourcePricing> azurePricing = pricingTemplate.getAzurePricing("EUR", "DE", Locale.GERMANY);
+
+		String[] expectedRates = new String[] {"0.055193985123456789", "2.8799074485", "3.35178018", "0.1003527", "16.185919239225"};
+
+		SoftAssertions.assertSoftly(softly -> {
+			IntStream.range(0, expectedRates.length).forEach(rateIndex -> {
+				BigDecimal actualRate = azurePricing.getBody().getMeters().get(rateIndex).getRates().get("0");
+				BigDecimal expectedRate = new BigDecimal(expectedRates[rateIndex]);
+				softly.assertThat(actualRate).isEqualTo(expectedRate);
+			});
 		});
 	}
 }

--- a/src/test/java/org/springframework/social/partnercenter/test/stubs/PricingOperationsStubs.java
+++ b/src/test/java/org/springframework/social/partnercenter/test/stubs/PricingOperationsStubs.java
@@ -19,11 +19,11 @@ public class PricingOperationsStubs {
 
 	public static void given_getAzurePricingForCurrencyAndRegion_returningRealRates(String currency, String region) {
 		String testUrl = String.format("/v1/ratecards/azure?currency=%s&region=%s", currency, region);
-		String resultJsonTemplate =  String.format("data/pricing/rates_%s_%s.json", currency, region);
+		String resultJsonTemplateFile =  String.format("data/pricing/rates_%s_%s.json", currency.toLowerCase(), region.toLowerCase());
 		stubFor(get(urlEqualTo(testUrl))
 				.willReturn(aResponse()
 						.withStatus(200)
 						.withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-						.withBody(parseFile(resultJsonTemplate).getAsString())));
+						.withBody(parseFile(resultJsonTemplateFile).getAsString())));
 	}
 }

--- a/src/test/java/org/springframework/social/partnercenter/test/stubs/PricingOperationsStubs.java
+++ b/src/test/java/org/springframework/social/partnercenter/test/stubs/PricingOperationsStubs.java
@@ -16,4 +16,14 @@ public class PricingOperationsStubs {
 						.withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
 						.withBody(parseFile("data/pricing/ok.json").getAsString())));
 	}
+
+	public static void given_getAzurePricingForCurrencyAndRegion_returningRealRates(String currency, String region) {
+		String testUrl = String.format("/v1/ratecards/azure?currency=%s&region=%s", currency, region);
+		String resultJsonTemplate =  String.format("data/pricing/rates_%s_%s.json", currency, region);
+		stubFor(get(urlEqualTo(testUrl))
+				.willReturn(aResponse()
+						.withStatus(200)
+						.withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+						.withBody(parseFile(resultJsonTemplate).getAsString())));
+	}
 }

--- a/src/test/resources/data/pricing/rates_eur_de.json
+++ b/src/test/resources/data/pricing/rates_eur_de.json
@@ -1,0 +1,77 @@
+{
+  "locale": "de-DE",
+  "currency": "EUR",
+  "isTaxIncluded": false,
+  "meters": [
+    {
+      "id": "d0bf9053-17c4-4fec-8502-4eb8376343a7",
+      "name": "F2/F2s mit niedriger Priorität",
+      "rates": {
+        "0": 0.055193985123456789
+      },
+      "tags": [],
+      "category": "Virtual Machines",
+      "subcategory": "F/FS-Serie – Windows ",
+      "region": "USA, Westen 2",
+      "unit": "1 Stunde",
+      "includedQuantity": 0,
+      "effectiveDate": "2017-04-01T00:00:00Z"
+    },
+    {
+      "id": "8b7672d4-16fc-446e-9935-cf2223c5290f",
+      "name": "S3-Sekundär-DTUs",
+      "rates": {
+        "0": 2.8799074485
+      },
+      "tags": [],
+      "category": "SQL-Datenbank",
+      "subcategory": "Single Standard",
+      "region": "Südkorea, Süden",
+      "unit": "1/Tag",
+      "includedQuantity": 0,
+      "effectiveDate": "2017-02-01T00:00:00Z"
+    },
+    {
+      "id": "c9c058cb-822e-46ae-86fb-6b583f91b4b5",
+      "name": "H16r mit niedriger Priorität",
+      "rates": {
+        "0": 3.35178018
+      },
+      "tags": [],
+      "category": "Cloud Services",
+      "subcategory": "H-Serie",
+      "region": "Australien, Osten",
+      "unit": "1 Stunde",
+      "includedQuantity": 0,
+      "effectiveDate": "2017-10-20T00:00:00Z"
+    },
+    {
+      "id": "0aaf975b-8e33-404b-93f7-de7d69774ca1",
+      "name": "D1 v2",
+      "rates": {
+        "0": 0.1003527
+      },
+      "tags": [],
+      "category": "Cloud Services",
+      "subcategory": "Dv2-Serie",
+      "region": "USA, Westen",
+      "unit": "1 Stunde",
+      "includedQuantity": 0,
+      "effectiveDate": "2016-02-01T00:00:00Z"
+    },
+    {
+      "id": "2a9b16cf-2b54-4f0a-93ca-232f83502b7b",
+      "name": "S2-Einheit",
+      "rates": {
+        "0": 16.185919239225
+      },
+      "tags": [],
+      "category": "Cognitive Services",
+      "subcategory": "Custom Recognition",
+      "region": "",
+      "unit": "1/Tag",
+      "includedQuantity": 0,
+      "effectiveDate": "2016-10-01T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
Change the data type for the rates Map in the `PricingMeter` class to use `BigDecimal` values instead of `double` to avoid loss of precision with large number of decimals