### PR TITLE
Changing the Extract Logic of continuation_token

### DIFF
--- a/src/main/java/org/springframework/social/partnercenter/api/PartnerCenterResponse.java
+++ b/src/main/java/org/springframework/social/partnercenter/api/PartnerCenterResponse.java
@@ -4,6 +4,9 @@ import static org.springframework.util.StringUtils.isEmpty;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -58,12 +61,23 @@ public class PartnerCenterResponse<T> {
 	}
 
 	public String getContinuationToken() {
-		return continuationToken;
+		return extractContinuationToken().orElse(null);
 	}
 
-	public PartnerCenterResponse setContinuationToken(String continuationToken) {
-		this.continuationToken = continuationToken;
-		return this;
+	public Optional<String> extractContinuationToken() {
+		return links.getNext().getHeaders()
+			.stream()
+			.filter(header -> header.key.equals("MS-ContinuationToken"))
+			.map(h -> h.value)
+			.map(this::parseContinuationToken)
+			.filter(Objects::nonNull)
+			.findFirst();
+	}
+
+	private String parseContinuationToken(String uri) {
+		return UriComponentsBuilder.fromUriString(uri)
+			.build()
+			.getQueryParams().getFirst("continuation_token");
 	}
 
 	public boolean hasNext(){


### PR DESCRIPTION

Here I am changing the extracting logic to fetch continuation_token in the Azure usage Response.

Earlier MS used to send the `continuation_token`
`},
  "totalCount" : 100,
  "continuationToken" : "eyJMaXN0Q......"
}`

But now MS is sending in below position 
`"links": {
    "self": {
      "uri": "customers/xxxxxxx/subscriptions/xxxxxxx/utilizations/azure?seek_operation=Next",
      "method": "GET",
      "headers": [
        {
          "key": "MS-ContinuationToken",
          "value": "/xxxxxxx/usage-records?entitlement_id=xxxxxxx&reported_start_time=2019-01-13+00%3a00%3a00Z&reported_end_time=2020-01-13+00%3a00%3a00Z&count=100&show_details=True&error_if_not_processed=True&granularity=Daily&continuation_token=eyJyIjoiMjAxOTA5MjgtNjM3MDUyMjU2MDAwMDAwMDAwIiwiaSI6Ik1vZG9NT1lXdXlFYmZBUE16aW9kQU9HbDJLM3dUVHFOcENLeVZ4QmY5MVBDVjZMdzFqMHgyNkFweTE3ZTMxNm5aV2hwNmRIWFRXRnhxMmJNVXdNUC9RPT0iLCJzIjoiUUFrTytwND0ifQ%3d%3d"
        }
      ]
    },
    "next": {
      "uri": "customers/xxxxxx/subscriptions/xxxxxx/utilizations/azure?seek_operation=Next",
      "method": "GET",
      "headers": [
        {
          "key": "MS-ContinuationToken",
          "value": "/xxxxxx/usage-records?entitlement_id=xxxxxx&reported_start_time=2019-01-13+00%3a00%3a00Z&reported_end_time=2020-01-13+00%3a00%3a00Z&count=100&show_details=True&error_if_not_processed=True&granularity=Daily&continuation_token=eyJyIjoiMjAxOTA5MzAtNjM3MDUzOTg0MDAwMDAwMDAwIiwiaSI6InkzRXFHbEJoSHE2Y2s0a3JmMjRQaWVPQkNzbW12SFFYd1NpcDJRS2IvMUk4aFNST1hreEs0djFyS3F0Zm9yL2RZdVErd3FjY2N5aitqdjhUUGxWeDJRPT0iLCJzIjoiTjQwbHlFOD0ifQ%3d%3d"
        }
      ]
    },`
