### PR TITLE
release/major/add-next-method : Added new `next` method for seek_operation=Next for Azure Utilization API

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,9 @@
 # Release Notes: Spring Social for Microsoft Partner Center
 
+## 9.5.0
+#### Added
+- Added new next method `ResponseEntity<PartnerCenterResponse<UtilizationRecord>> next(String continuationToken, String customerId, String subscriptionId)`
+
 ## 9.4.0
 #### Added
 - Added missing `upgradeTargetOffers` attribute to `Offer` bean

--- a/src/main/java/org/springframework/social/partnercenter/api/PagingResourceOperations.java
+++ b/src/main/java/org/springframework/social/partnercenter/api/PagingResourceOperations.java
@@ -1,6 +1,7 @@
 package org.springframework.social.partnercenter.api;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.social.partnercenter.api.billing.usage.UtilizationRecord;
 
 public interface PagingResourceOperations<T> {
 	ResponseEntity<PartnerCenterResponse<T>> next(String continuationToken);
@@ -8,4 +9,5 @@ public interface PagingResourceOperations<T> {
 	ResponseEntity<PartnerCenterResponse<T>> first(String continuationToken);
 	ResponseEntity<PartnerCenterResponse<T>> last(String continuationToken);
 	ResponseEntity<PartnerCenterResponse<T>> page(String continuationToken, int pageIndex);
+	ResponseEntity<PartnerCenterResponse<UtilizationRecord>> next(String continuationToken,String customerId, String subscriptionId);
 }

--- a/src/main/java/org/springframework/social/partnercenter/api/PagingResourceTemplate.java
+++ b/src/main/java/org/springframework/social/partnercenter/api/PagingResourceTemplate.java
@@ -5,10 +5,12 @@ import static org.springframework.social.partnercenter.http.PartnerCenterHttpHea
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.ResponseEntity;
 import org.springframework.social.partnercenter.PartnerCenter;
+import org.springframework.social.partnercenter.api.billing.usage.UtilizationRecord;
 import org.springframework.social.partnercenter.http.client.RestResource;
 
 public class PagingResourceTemplate<T> extends AbstractTemplate implements PagingResourceOperations<T>{
 	private final RestResource restResource;
+	private static final String SUBSCRIPTIONS = "subscriptions";
 	private ParameterizedTypeReference<PartnerCenterResponse<T>> typeReference;
 	protected PagingResourceTemplate(RestResource restResource, boolean isAuthorized, ParameterizedTypeReference<PartnerCenterResponse<T>> typeReference) {
 		super(isAuthorized);
@@ -55,6 +57,15 @@ public class PagingResourceTemplate<T> extends AbstractTemplate implements Pagin
 				.queryParam("seekOperation", SeekOperation.PAGE_INDEX.getValue())
 				.queryParam("page", pageIndex)
 				.get(typeReference);
+	}
+
+	@Override
+	public ResponseEntity<PartnerCenterResponse<UtilizationRecord>> next(String continuationToken, String customerId, String subscriptionId) {
+		return restResource.request()
+			.header(MS_CONTINUATION_TOKEN, continuationToken)
+			.pathSegment(customerId, SUBSCRIPTIONS, subscriptionId)
+			.queryParam("seekOperation", SeekOperation.PREVIOUS.getValue())
+			.get((new ParameterizedTypeReference<PartnerCenterResponse<UtilizationRecord>>() {}));
 	}
 
 	@Override


### PR DESCRIPTION
Currently when we are calling seek_operation=Next 
API sent :- 
https://api.partnercenter.microsoft.com/v1/customers?seekOperation=next

API should be :- 
https://api.partnercenter.microsoft.com/v1/customers/{customers}/subscriptions/{subscriptions}/utilizations/azure?
seek_operation=Next
