### PR TITLE
PI-16891 Changed seekOperation to NEXT

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,11 +1,16 @@
 # Release Notes: Spring Social for Microsoft Partner Center
 
+## 10.1.1
+#### Changed
+- Changed next method to used operationSeek NEXT
 
-## 9.5.0
-#### Added
-- Added new next method `ResponseEntity<PartnerCenterResponse<UtilizationRecord>> next(String continuationToken, String customerId, String subscriptionId)`
+## 10.1.0
 #### Changed
 - Change definition of new next method `ResponseEntity<PartnerCenterResponse<UtilizationRecord>> next(String continuationToken, String customerId, String subscriptionId)`
+
+## 10.0.0
+#### Added
+- Added new next method `ResponseEntity<PartnerCenterResponse<UtilizationRecord>> next(String continuationToken, String customerId, String subscriptionId)`
 
 ## 9.4.0
 #### Added

--- a/src/main/java/org/springframework/social/partnercenter/api/PagingResourceTemplate.java
+++ b/src/main/java/org/springframework/social/partnercenter/api/PagingResourceTemplate.java
@@ -66,7 +66,7 @@ public class PagingResourceTemplate<T> extends AbstractTemplate implements Pagin
 		return restResource.request()
 			.header(MS_CONTINUATION_TOKEN, continuationToken)
 			.pathSegment(customerId, SUBSCRIPTIONS, subscriptionId, UTILIZATIONS, AZURE)
-			.queryParam("seekOperation", SeekOperation.PREVIOUS.getValue())
+			.queryParam("seekOperation", SeekOperation.NEXT.getValue())
 			.get((new ParameterizedTypeReference<PartnerCenterResponse<UtilizationRecord>>() {}));
 	}
 


### PR DESCRIPTION
Fixed `ResponseEntity<PartnerCenterResponse<UtilizationRecord>> next(String continuationToken, String customerId, String subscriptionId)` to use `SeekOperation.NEXT.getValue()`